### PR TITLE
Fix `npm link` in *unix systems, fixes #93

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('v8-argv')('--harmony', __dirname + '/dist/bin/cli/program');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "preferGlobal": true,
   "bin": {
-    "harmonic": "dist/harmonic.js"
+    "harmonic": "bin.js"
   },
   "files": [
     "dist",

--- a/src/harmonic.js
+++ b/src/harmonic.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('v8-argv')('--harmony', __dirname + '/bin/cli/program');

--- a/src/test/main.js
+++ b/src/test/main.js
@@ -10,7 +10,7 @@ var helpers = require('../bin/helpers.js'),
     cprocess = require('child_process'),
     spawn = cprocess.spawn,
     _ = require('underscore'),
-    harmonicBin = path.join(__dirname, '..', 'harmonic.js'),
+    harmonicBin = path.join(__dirname, '../../bin.js'),
     testDir = path.join(__dirname, 'site'),
     stdoutWrite = process.stdout.write;
 require('should');


### PR DESCRIPTION
`npm link` was not working properly in *unix systems, as each build deletes the symlinked file.
This commit moves the symlinked file to outside of dist.