### PR TITLE
Add Node 0.10 compatibility, remove --harmony and v8-argv, update structure, bump deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "0.10"
   - "0.11"
 install: ""
 # `npm i` without any arguments triggers the `prepublish` script which builds and tests

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Harmonic is being developed with some goals:
 Check out the full documentation in [Harmonic's Wiki](https://github.com/es6rocks/harmonic/wiki/).
 
 ## Installing
-**Attention:** Harmonic uses some ES6 features. You will need to install Node.js >= 0.11.13.  
-Using a Node.js version manager, such as [nvm](https://github.com/creationix/nvm) or [n](https://github.com/visionmedia/n), is a good approach to have multiple Node.js versions and not break any existing Node.js software that you already have installed.  
 
 Harmonic is available on npm:  
 

--- a/bin.js
+++ b/bin.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('v8-argv')('--harmony', __dirname + '/dist/bin/cli/harmonic');

--- a/build.js
+++ b/build.js
@@ -8,7 +8,7 @@ module.exports = {
 	distBase: 'dist/',
 	config: {
 		jscs: { configPath: '.jscsrc', esnext: true },
-		'6to5': { blacklist: ['generators'] },
+		'6to5': { modules: 'commonStrict'/*, experimental: true*/ },
 		mocha: { bail: true, timeout: 5000 }
 	}
 };

--- a/entry_points/README.md
+++ b/entry_points/README.md
@@ -1,0 +1,8 @@
+# Entry points
+
+This directory exists for two reasons:
+
+- Abstract away the polyfills required by 6to5;
+- Work around a `npm link` issue in Unix-based OS's -- if these files were inside `dist`, generating a new build would break the symlinks.
+
+Put your `main` entry point's logic in the `src/index.js` file.

--- a/entry_points/harmonic.js
+++ b/entry_points/harmonic.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 require('./lib/polyfill');

--- a/entry_points/harmonic.js
+++ b/entry_points/harmonic.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./lib/polyfill');
+module.exports = require('../dist/bin/cli/harmonic');

--- a/entry_points/lib/polyfill.js
+++ b/entry_points/lib/polyfill.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('core-js/shim');
+require('regenerator/runtime');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ gulp.task('default', ['build'], function(neverEnd) {
 			.pipe(uniqueStream, 'path'),
 
 			existsFilter = lazypipe()
-				.pipe(plugins.filter, filterEvent.bind(null, ['changed', 'added'])),
+				.pipe(plugins.filter, filterEvent.bind(null, ['change', 'add'])),
 
 				handleJs = lazypipe()
 					.pipe(plugins.filter, build.src.js)
@@ -72,7 +72,7 @@ gulp.task('default', ['build'], function(neverEnd) {
 					.pipe(writePipe),
 
 			handleDeletion = lazypipe()
-				.pipe(plugins.filter, filterEvent.bind(null, ['deleted']))
+				.pipe(plugins.filter, filterEvent.bind(null, ['unlink']))
 				.pipe(plugins.rename, function(filePath) {
 					// we can't change/remove the filePath's `base`, so cd out of it in the dirname
 					filePath.dirname = path.join(path.relative(build.srcBase, '.'), build.distBase, filePath.dirname);

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "homepage": "https://github.com/es6rocks/harmonic",
   "version": "0.0.9",
   "engines": {
-    "node": ">=0.11.13"
+    "node": ">=0.10"
   },
   "preferGlobal": true,
   "bin": {
-    "harmonic": "bin.js"
+    "harmonic": "entry_points/harmonic.js"
   },
   "files": [
     "dist",
     "!dist/test",
+    "entry_points",
     "LICENSE"
   ],
   "repository": {
@@ -24,7 +25,7 @@
     "co": "~3.0.5",
     "co-prompt": "^1.0.0",
     "commander": "~2.2.0",
-    "core-js": "^0.4.5",
+    "core-js": "^0.4.9",
     "less": "^1.7.5",
     "markdown-extra": "^0.1.0",
     "marked": "~0.3.2",
@@ -37,8 +38,7 @@
     "regenerator": "^0.8.9",
     "rimraf": "^2.2.8",
     "stylus": "^0.45.1",
-    "underscore": "^1.6.0",
-    "v8-argv": "^0.2.0"
+    "underscore": "^1.6.0"
   },
   "devDependencies": {
     "chalk": "^0.5.1",
@@ -52,9 +52,9 @@
     "gulp-load-plugins": "^0.8.0",
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
-    "gulp-src-ordered-globs": "^1.0.2",
+    "gulp-src-ordered-globs": "^1.0.3",
     "gulp-util": "^3.0.1",
-    "gulp-watch": "^3.0.0",
+    "gulp-watch": "^4.1.0",
     "jshint-stylish": "^1.0.0",
     "lazypipe": "^0.2.2",
     "merge-stream": "^0.1.6",
@@ -62,14 +62,14 @@
     "reversepoint": "^0.2.1",
     "should": "^4.4.1",
     "through": "^2.3.6",
-    "unique-stream": "^1.0.0",
+    "unique-stream": "^2.0.2",
     "vinyl-paths": "^1.0.0"
   },
   "author": "Jaydson Gomes <jayalemao@gmail.com> (http://jaydson.org/)",
   "license": "MIT",
   "scripts": {
-    "dev": "node --harmony ./node_modules/gulp/bin/gulp",
+    "dev": "gulp",
     "prepublish": "npm i gulp-6to5 && npm test",
-    "test": "node --harmony ./node_modules/gulp/bin/gulp build"
+    "test": "gulp build"
   }
 }

--- a/src/test/main.js
+++ b/src/test/main.js
@@ -1,4 +1,6 @@
 /* jshint mocha: true */
+require('../../entry_points/lib/polyfill');
+
 import Parser from '../bin/parser';
 
 var helpers = require('../bin/helpers.js'),
@@ -10,7 +12,7 @@ var helpers = require('../bin/helpers.js'),
     cprocess = require('child_process'),
     spawn = cprocess.spawn,
     _ = require('underscore'),
-    harmonicBin = path.join(__dirname, '../../bin.js'),
+    harmonicBin = path.join(__dirname, '../../entry_points/harmonic'),
     testDir = path.join(__dirname, 'site'),
     stdoutWrite = process.stdout.write;
 require('should');


### PR DESCRIPTION
Apart from adding Node 0.10 compatibility, this commit also includes:

- Fixed a publishing issue -- the package entry point was missing from `package.json`'s `files`. The newly added entry points directory is not transpiled as to not break `npm link` (#93). The entry points directory contains virtually no logic, it simply abstracts away the polyfills required by 6to5 as to not pollute the main `src` files, and `require()`s the actual entry point logic which resides in the `src` directory.

- Updated gulp-watch -- our development workflow watcher is Chokidar now.

**NOTE:** you may need to `npm link` again after pulling this commit.

Resolves #106