### PR TITLE
Enhancement to enable running harmonic commands from subfolders

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,6 +8,6 @@ module.exports = {
 	distBase: 'dist/',
 	config: {
 		babel: { optional: ['runtime'], stage: 0 },
-		mocha: '--colors --bail --timeout 5000'
+		mocha: '--colors --bail --timeout 15000'
 	}
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "harmonic",
   "description": "The next static site generator",
   "homepage": "https://github.com/es6rocks/harmonic",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "engines": {
     "node": ">=0.10"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "harmonic",
   "description": "The next static site generator",
   "homepage": "https://github.com/es6rocks/harmonic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "engines": {
     "node": ">=0.10"
   },

--- a/src/bin/cli/harmonic.js
+++ b/src/bin/cli/harmonic.js
@@ -1,6 +1,6 @@
 import program from 'commander';
 import { version } from '../config';
-import { cliColor } from '../helpers';
+import { cliColor, findHarmonicRoot } from '../helpers';
 import logo from './logo';
 import { init, config, newFile, run } from './util';
 import { build } from '../core';
@@ -12,7 +12,7 @@ program
 program
     .command('init [path]')
     .description('Init your static website')
-    .action((path = '.') => {
+    .action((path = findHarmonicRoot('.')) => {
         console.log(logo);
         init(path);
     });
@@ -20,7 +20,7 @@ program
 program
     .command('config [path]')
     .description('Config your static website')
-    .action(async (path = '.') => {
+    .action(async (path = findHarmonicRoot('.')) => {
         console.log(logo);
         await config(path);
         console.log(clc.info('\nharmonic.json successfully updated.'));
@@ -29,7 +29,7 @@ program
 program
     .command('build [path]')
     .description('Build your static website')
-    .action((path = '.') => {
+    .action((path = findHarmonicRoot('.')) => {
         build(path);
     });
 
@@ -37,7 +37,7 @@ program
     .command('new_post <title> [path]')
     .option('--no-open', 'Don\'t open the markdown file(s) in editor')
     .description('Create a new post')
-    .action((title, path = '.', { open: autoOpen }) => {
+    .action((title, path = findHarmonicRoot('.'), { open: autoOpen }) => {
         newFile(path, 'post', title, autoOpen);
     });
 
@@ -45,7 +45,7 @@ program
     .command('new_page <title> [path]')
     .option('--no-open', 'Don\'t open the markdown file(s) in editor')
     .description('Create a new page')
-    .action((title, path = '.', { open: autoOpen }) => {
+    .action((title, path = findHarmonicRoot('.'), { open: autoOpen }) => {
         newFile(path, 'page', title, autoOpen);
     });
 
@@ -53,7 +53,7 @@ program
     .command('run [port] [path]')
     .option('--no-open', 'Don\'t open a new browser window')
     .description('Run you static site locally. Port is optional')
-    .action((port = 9356, path = '.', { open: autoOpen }) => {
+    .action((port = 9356, path = findHarmonicRoot('.'), { open: autoOpen }) => {
         build(path).then(function() {
             run(path, port, autoOpen);
         });

--- a/src/bin/cli/harmonic.js
+++ b/src/bin/cli/harmonic.js
@@ -1,6 +1,6 @@
 import program from 'commander';
 import { version } from '../config';
-import { cliColor, findHarmonicRoot } from '../helpers';
+import { cliColor } from '../helpers';
 import logo from './logo';
 import { init, config, newFile, run } from './util';
 import { build } from '../core';
@@ -12,7 +12,7 @@ program
 program
     .command('init [path]')
     .description('Init your static website')
-    .action((path = findHarmonicRoot('.')) => {
+    .action((path = '.') => {
         console.log(logo);
         init(path);
     });
@@ -20,7 +20,7 @@ program
 program
     .command('config [path]')
     .description('Config your static website')
-    .action(async (path = findHarmonicRoot('.')) => {
+    .action(async (path = '.') => {
         console.log(logo);
         await config(path);
         console.log(clc.info('\nharmonic.json successfully updated.'));
@@ -29,7 +29,7 @@ program
 program
     .command('build [path]')
     .description('Build your static website')
-    .action((path = findHarmonicRoot('.')) => {
+    .action((path = '.') => {
         build(path);
     });
 
@@ -37,7 +37,7 @@ program
     .command('new_post <title> [path]')
     .option('--no-open', 'Don\'t open the markdown file(s) in editor')
     .description('Create a new post')
-    .action((title, path = findHarmonicRoot('.'), { open: autoOpen }) => {
+    .action((title, path = '.', { open: autoOpen }) => {
         newFile(path, 'post', title, autoOpen);
     });
 
@@ -45,7 +45,7 @@ program
     .command('new_page <title> [path]')
     .option('--no-open', 'Don\'t open the markdown file(s) in editor')
     .description('Create a new page')
-    .action((title, path = findHarmonicRoot('.'), { open: autoOpen }) => {
+    .action((title, path = '.', { open: autoOpen }) => {
         newFile(path, 'page', title, autoOpen);
     });
 
@@ -53,7 +53,7 @@ program
     .command('run [port] [path]')
     .option('--no-open', 'Don\'t open a new browser window')
     .description('Run you static site locally. Port is optional')
-    .action((port = 9356, path = findHarmonicRoot('.'), { open: autoOpen }) => {
+    .action((port = 9356, path = '.', { open: autoOpen }) => {
         build(path).then(function() {
             run(path, port, autoOpen);
         });

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -1,14 +1,12 @@
-import { isHarmonicProject } from './helpers';
+import { isHarmonicProject, findHarmonicRoot } from './helpers';
 import Harmonic from './parser';
 
 export { build };
 
 async function build(sitePath) {
     try {
-        // TODO move logging to outside of isHarmonicProject and API functions
-        if (!isHarmonicProject(sitePath)) {
-            throw new Error();
-        }
+        
+        sitePath = findHarmonicRoot(sitePath);
 
         const harmonic = new Harmonic(sitePath, { quiet: false });
 

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -1,13 +1,18 @@
-import { isHarmonicProject, findHarmonicRoot } from './helpers';
+import { isHarmonicProject, findHarmonicRoot, displayNonInitializedFolderErrorMessage, MissingFileError } from './helpers';
 import Harmonic from './parser';
 
 export { build };
 
-async function build(sitePath) {
+async function build(passedPath) {
     try {
         
-        sitePath = findHarmonicRoot(sitePath);
-
+        const sitePath = findHarmonicRoot(passedPath);
+        
+        if (!sitePath) {
+            displayNonInitializedFolderErrorMessage();
+            throw new MissingFileError();
+        }
+       
         const harmonic = new Harmonic(sitePath, { quiet: false });
 
         harmonic.start(); // useless, remove?

--- a/src/bin/helpers.js
+++ b/src/bin/helpers.js
@@ -4,7 +4,8 @@ import _cliColor from 'cli-color';
 import { resolve } from 'path';
 
 
-export { cliColor, isHarmonicProject, getConfig, titleToFilename, findHarmonicRoot };
+export { cliColor, isHarmonicProject, getConfig, titleToFilename, 
+    findHarmonicRoot, displayNonInitializedFolderErrorMessage, MissingFileError };
 
 // CLI color
 function cliColor() {
@@ -28,31 +29,26 @@ function displayNonInitializedFolderErrorMessage() {
     );
 }
 
-// Find harmonic.json
+// Find harmonic.json. Returns path or false.
 function findHarmonicRoot(sitePath) {
     
-    const clc = cliColor();
     var currentPath = resolve(sitePath);
     var oldPath = "";
 
 
     while (!isHarmonicProject(currentPath)) {
-        // TODO: Climb folders up until find harmonic.json file, if can't find then error.
+        // TODO: Climb folders up until find harmonic.json file, if can't find then return false.
 
         oldPath = currentPath;
         currentPath = resolve(currentPath,"..");
 
         if (oldPath === currentPath) {
-            // reached root folder, throw error;
-            displayNonInitializedFolderErrorMessage();
-            throw new Error();
+            // reached root folder, return false;
+            return false;
         }
 
     }
-
-    console.log(
-        clc.info("harmonic.json found at: " + currentPath)
-    );
+    
     return currentPath;
 }
 
@@ -69,9 +65,21 @@ function isHarmonicProject(sitePath) {
 }
 
 function getConfig(sitePath) {
+    
     return JSON.parse(readFileSync(join(sitePath, 'harmonic.json')).toString());
 }
+
 
 function titleToFilename(title) {
     return title.replace(/[^a-z0-9]+/gi, '-').replace(/^-*|-*$/g, '').toLowerCase() + '.md';
 }
+
+// New Error for Harmonic missing configuration file
+function MissingFileError(file) {
+    this.name = 'MissingFileError';
+    this.file = file || "harmonic.json";
+    this.message = `Missing file: ${this.file}`;
+   
+}
+MissingFileError.prototype = Object.create(Error.prototype);
+MissingFileError.prototype.constructor = MissingFileError;

--- a/src/bin/helpers.js
+++ b/src/bin/helpers.js
@@ -1,8 +1,10 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import _cliColor from 'cli-color';
+import { resolve } from 'path';
 
-export { cliColor, isHarmonicProject, getConfig, titleToFilename };
+
+export { cliColor, isHarmonicProject, getConfig, titleToFilename, findHarmonicRoot };
 
 // CLI color
 function cliColor() {
@@ -14,20 +16,54 @@ function cliColor() {
     };
 }
 
+// Friendly message for non-initialized folder
+function displayNonInitializedFolderErrorMessage() {
+    const clc = cliColor();
+
+    console.log(
+        clc.warn('It seems this is not an Harmonic project yet. \n') +
+        clc.warn('Check your directory or run ') +
+        clc.info.bgWhite.italic(' harmonic init ') +
+        clc.warn(' to start a new Harmonic project.')
+    );
+}
+
+// Find harmonic.json
+function findHarmonicRoot(sitePath) {
+    
+    const clc = cliColor();
+    var currentPath = resolve(sitePath);
+    var oldPath = "";
+
+
+    while (!isHarmonicProject(currentPath)) {
+        // TODO: Climb folders up until find harmonic.json file, if can't find then error.
+
+        oldPath = currentPath;
+        currentPath = resolve(currentPath,"..");
+
+        if (oldPath === currentPath) {
+            // reached root folder, throw error;
+            displayNonInitializedFolderErrorMessage();
+            throw new Error();
+        }
+
+    }
+
+    console.log(
+        clc.info("harmonic.json found at: " + currentPath)
+    );
+    return currentPath;
+}
+
 // Check if harmonic.json file exists
 function isHarmonicProject(sitePath) {
-    const clc = cliColor();
 
     try {
         getConfig(sitePath);
         return true;
     } catch (e) {
-        console.log(
-            clc.warn('It seems this is not an Harmonic project yet. \n') +
-            clc.warn('Check your directory or run ') +
-            clc.info.bgWhite.italic(' harmonic init ') +
-            clc.warn(' to start a new Harmonic project.')
-        );
+       
         return false;
     }
 }

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -284,7 +284,7 @@ export default class Harmonic {
                     // and handle the possible error.
                     //
                     // We'll still log the error to output though...
-                    console.log(clc.warn(`Harmonic didn't to copy the users's resources.`));
+                    console.log(clc.warn(`Harmonic did not copy any user resources.`));
                 } else {
                     console.log(clc.info(`User resources copied`));
                 }
@@ -292,7 +292,7 @@ export default class Harmonic {
             });
         });
 
-       
+
     }
 
     async generatePosts(files) {


### PR DESCRIPTION
This pull request enables running the "build", "new_post", "new_page" and "run" commands from anywhere inside an harmonic site.

It works by creating a new ```findHarmonicRoot()``` helper function that will look into the current folder for ```harmonic.json``` and if not found it will start climbing to the parent folders until it finds it. Once the config file is found it returns it. If the config file is not found anywhere it displays a friendly error message and throws an error.

This leads to a better user experience because they don't need to return to the folder where ```harmonic.json``` is located before running any command.