### PR TITLE
Enhancement: adds user defined resource folder that is copied to public

### DIFF
--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -26,7 +26,8 @@ async function build(sitePath) {
         harmonic.generateIndex(postsMetadata, pagesMetadata);
         harmonic.generateTagsPages(postsMetadata);
 
-        await harmonic.copyResources();
+        await harmonic.copyThemeResources();
+        await harmonic.copyUserResources();
     } catch (e) {
         console.log(e);
         console.log(e.stack);

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -260,7 +260,7 @@ export default class Harmonic {
         }
     }
 
-    async copyResources() {
+    async copyThemeResources() {
         await new Promise((resolve, reject) => {
             const curTemplate = this.theme.themePath;
             ncp(path.join(curTemplate, 'resources'), path.join(this.sitePath, 'public'), (err) => {
@@ -271,7 +271,28 @@ export default class Harmonic {
             });
         });
 
-        console.log(clc.info('Resources copied'));
+        console.log(clc.info('Theme resources copied'));
+    }
+
+    async copyUserResources() {
+        await new Promise((resolve, reject) => {
+            ncp(path.join(this.sitePath, 'resources'), path.join(this.sitePath, 'public'), (err) => {
+                if (err) {
+                    // no need to throw error. The user might just not have a resources folder.
+                    // I am not checking for its presence with fs.exists and fs.existsSync because
+                    // node docs says it will be deprecated. Their advise is to try to use the file/folder
+                    // and handle the possible error.
+                    //
+                    // We'll still log the error to output though...
+                    console.log(clc.warn(`Harmonic didn't to copy the users's resources.`));
+                } else {
+                    console.log(clc.info(`User resources copied`));
+                }
+                resolve();
+            });
+        });
+
+       
     }
 
     async generatePosts(files) {

--- a/src/bin/skeleton/resources/readme.txt
+++ b/src/bin/skeleton/resources/readme.txt
@@ -1,0 +1,3 @@
+Add files to this folder to have them copied to the final site during build time.
+
+PS: You can remove this file.


### PR DESCRIPTION
This enhancement adds a user defined ```resources``` folder that is copied to ```public``` during build. This folder is copied after the theme's resources are copied so it can be used to overlay items as well. 

If there is no ```resources``` folder present then Harmonic displays a warning saying that no user resources were copied during build. This happens if the folder is not present or if there was an error in the copying process. Node documentations says that ```fs.exists``` and ```fs.existsSync``` will be deprecated and I didn't want to use functions that will soon go away thus generating debug work for my future self.

This was implemented by splitting the ```copyResources()``` function into two functions called ```copyThemeResources``` and ```copyUserResources``` as mentioned in #138 (which is solved by this PR).

Hope your folks like it, it makes things a lot easier for me at least.